### PR TITLE
Prediction printing

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -32,6 +32,7 @@ Depends:
     R (>= 3.1)
 Imports: 
     caret,
+    cli,
     DMwR,
     dplyr,
     e1071,

--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -2,8 +2,8 @@ Type: Package
 Package: splendid
 Title: SuPervised Learning ENsemble for Diagnostic
     IDentification
-Version: 0.1.0.9001
-Date: 2019-05-28
+Version: 0.1.0.9002
+Date: 2019-05-29
 Authors@R: 
     c(person(given = "Derek",
              family = "Chiu",

--- a/NEWS.md
+++ b/NEWS.md
@@ -2,6 +2,8 @@
 
 ## New Features
 
+* add custom print method for objects returned from `prediction()`. The output was previously not informative and too long
+
 * add parameter `seed_samp` to `splendid()` to allow setting random seed before subsampling
 
 * `splendid_convert()` is now defunct. Use `splendid_process()` for a more comprehensive data pre-processing step. The new function can `convert` categorical variables to dummy variables as before. Added the ability to `standardize` continuous variables and apply `sampling` techniques to deal with class imbalance. Subsampling can only occur on the training set.

--- a/R/prediction.R
+++ b/R/prediction.R
@@ -294,7 +294,8 @@ prediction_output <- function(pred, prob, class, test.id, threshold) {
     prob = prob,
     class.true = ctr,
     class.thres = cth,
-    class.prop = cp
+    class.prop = cp,
+    class = c("prediction", "factor")
   )
 }
 
@@ -343,4 +344,14 @@ split_data <- function(data, test.id = NULL, train.id = NULL,
     }
   }
   tibble::lst(train, test)
+}
+
+#' Custom printing method for prediction output
+#' @noRd
+print.prediction <- function(x, ...) {
+  cli::cat_line(cli::style_bold("# Prediction Summary\n"))
+  cli::cat_line("Confusion Matrix")
+  print(conf_mat(attr(x, "class.true"), attr(x, "class.thres")))
+  cli::cat_line()
+  cli::cat_line("Proportion of Classified Predictions: ", attr(x, "class.prop"))
 }

--- a/R/prediction.R
+++ b/R/prediction.R
@@ -349,9 +349,9 @@ split_data <- function(data, test.id = NULL, train.id = NULL,
 #' Custom printing method for prediction output
 #' @noRd
 print.prediction <- function(x, ...) {
-  cli::cat_line(cli::style_bold("# Prediction Summary\n"))
+  cli::cat_line(cli::col_blue("# Prediction Summary\n"))
   cli::cat_line("Confusion Matrix")
   print(conf_mat(attr(x, "class.true"), attr(x, "class.thres")))
-  cli::cat_line()
+  cli::cat_line("\nTotal Cases: ",length(x))
   cli::cat_line("Proportion of Classified Predictions: ", attr(x, "class.prop"))
 }


### PR DESCRIPTION
- The output from `prediction()` was not informative and too long (showed the prediction, probability matrix, thresholded predictions, true predictions, and proportion of classified cases). The object itself hasn't changed, but the print method summarizes the information